### PR TITLE
Update package.json to support react 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,8 +145,8 @@
     "webpack": "4.42.1"
   },
   "peerDependencies": {
-    "react": "^16.8.5 || ^17.0.0",
-    "react-dom": "^16.8.5 || ^17.0.0"
+    "react": "^16.8.5 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.5 || ^17.0.0 || ^18.0.0"
   },
   "license": "Apache-2.0",
   "jest-junit": {


### PR DESCRIPTION
There are a lot of people looking for React 18 support over on the Atlassian site.  The dnd lib works fine, but we just need to get the package.json support.  Can you merge and publish?